### PR TITLE
Clean up all temp files created during processing and storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ erl_crash.dump
 .DS_Store
 /waffletest
 /doc
+.env

--- a/lib/waffle/actions/store.ex
+++ b/lib/waffle/actions/store.ex
@@ -20,9 +20,21 @@ defmodule Waffle.Actions.Store do
   defp put(_definition, { error = {:error, _msg}, _scope}), do: error
   defp put(definition, {%Waffle.File{}=file, scope}) do
     case definition.validate({file, scope}) do
-      true -> put_versions(definition, {file, scope})
+      true ->
+        put_versions(definition, {file, scope})
+        |> cleanup(file)
       _    -> {:error, :invalid_file}
     end
+  end
+
+  defp cleanup(result, file) do
+    # If we were working with binary data or a remote file, a tempfile was
+    # created that we need to clean up.
+    if file.tempfile? do
+      File.rm(file.path)
+    end
+
+    result
   end
 
   defp put_versions(definition, {file, scope}) do
@@ -81,6 +93,13 @@ defmodule Waffle.Actions.Store do
         file_name = Waffle.Definition.Versioning.resolve_file_name(definition, version, {file, scope})
         file      = %Waffle.File{file | file_name: file_name}
         result = definition.__storage.put(definition, version, {file, scope})
+
+        # If this version was transformed in any way, a tempfile was created
+        # that we need to clean up.
+        if file.tempfile? do
+          File.rm(file.path)
+        end
+
         result
     end
   end

--- a/lib/waffle/actions/store.ex
+++ b/lib/waffle/actions/store.ex
@@ -22,20 +22,11 @@ defmodule Waffle.Actions.Store do
     case definition.validate({file, scope}) do
       true ->
         put_versions(definition, {file, scope})
-        |> cleanup(file)
+        |> cleanup!(file)
       _    -> {:error, :invalid_file}
     end
   end
 
-  defp cleanup(result, file) do
-    # If we were working with binary data or a remote file, a tempfile was
-    # created that we need to clean up.
-    if file.tempfile? do
-      File.rm(file.path)
-    end
-
-    result
-  end
 
   defp put_versions(definition, {file, scope}) do
     if definition.async do
@@ -92,15 +83,20 @@ defmodule Waffle.Actions.Store do
       {:ok, file} ->
         file_name = Waffle.Definition.Versioning.resolve_file_name(definition, version, {file, scope})
         file      = %Waffle.File{file | file_name: file_name}
-        result = definition.__storage.put(definition, version, {file, scope})
 
-        # If this version was transformed in any way, a tempfile was created
-        # that we need to clean up.
-        if file.tempfile? do
-          File.rm(file.path)
-        end
-
-        result
+        definition.__storage.put(definition, version, {file, scope})
+        |> cleanup!(file)
     end
   end
+
+  defp cleanup!(result, file) do
+    # If we were working with binary data or a remote file, a tempfile was
+    # created that we need to clean up.
+    if file.is_tempfile? do
+      File.rm!(file.path)
+    end
+
+    result
+  end
+
 end

--- a/lib/waffle/file.ex
+++ b/lib/waffle/file.ex
@@ -47,7 +47,7 @@ end
 
   defp write_binary(file) do
     path = generate_temporary_path(file)
-    :ok = File.write!(path, file.binary)
+    File.write!(path, file.binary)
 
     %__MODULE__{
       file_name: file.file_name,

--- a/lib/waffle/file.ex
+++ b/lib/waffle/file.ex
@@ -1,5 +1,5 @@
 defmodule Waffle.File do
-  defstruct [:path, :file_name, :binary]
+  defstruct [:path, :file_name, :binary, :tempfile?]
 
   def generate_temporary_path(file \\ nil) do
     extension = Path.extname((file && file.path) || "")
@@ -18,7 +18,7 @@ defmodule Waffle.File do
     filename = Path.basename(uri.path)
 
     case save_file(uri, filename) do
-      {:ok, local_path} -> %Waffle.File{path: local_path, file_name: filename}
+      {:ok, local_path} -> %Waffle.File{path: local_path, file_name: filename, tempfile?: true}
       :error -> {:error, :invalid_file_path}
     end
 end
@@ -33,6 +33,7 @@ end
 
   def new(%{filename: filename, binary: binary}) do
     %Waffle.File{binary: binary, file_name: Path.basename(filename)}
+    |> write_binary()
   end
 
   # Accepts a map conforming to %Plug.Upload{} syntax
@@ -43,8 +44,6 @@ end
     end
   end
 
-  def ensure_path(file = %{path: path}) when is_binary(path), do: file
-  def ensure_path(file = %{binary: binary}) when is_binary(binary), do: write_binary(file)
 
   defp write_binary(file) do
     path = generate_temporary_path(file)
@@ -52,7 +51,8 @@ end
 
     %__MODULE__{
       file_name: file.file_name,
-      path: path
+      path: path,
+      tempfile?: true
     }
   end
 

--- a/lib/waffle/file.ex
+++ b/lib/waffle/file.ex
@@ -1,5 +1,5 @@
 defmodule Waffle.File do
-  defstruct [:path, :file_name, :binary, :tempfile?]
+  defstruct [:path, :file_name, :binary, :is_tempfile?]
 
   def generate_temporary_path(file \\ nil) do
     extension = Path.extname((file && file.path) || "")
@@ -18,7 +18,7 @@ defmodule Waffle.File do
     filename = Path.basename(uri.path)
 
     case save_file(uri, filename) do
-      {:ok, local_path} -> %Waffle.File{path: local_path, file_name: filename, tempfile?: true}
+      {:ok, local_path} -> %Waffle.File{path: local_path, file_name: filename, is_tempfile?: true}
       :error -> {:error, :invalid_file_path}
     end
 end
@@ -52,7 +52,7 @@ end
     %__MODULE__{
       file_name: file.file_name,
       path: path,
-      tempfile?: true
+      is_tempfile?: true
     }
   end
 

--- a/lib/waffle/processor.ex
+++ b/lib/waffle/processor.ex
@@ -12,6 +12,6 @@ defmodule Waffle.Processor do
   end
 
   defp apply_transformation(file, {cmd, conversion}) do
-    Waffle.Transformations.Convert.apply(cmd, Waffle.File.ensure_path(file), conversion)
+    Waffle.Transformations.Convert.apply(cmd, file, conversion)
   end
 end

--- a/lib/waffle/transformations/convert.ex
+++ b/lib/waffle/transformations/convert.ex
@@ -6,9 +6,10 @@ defmodule Waffle.Transformations.Convert do
 
     ensure_executable_exists!(program)
 
-    case System.cmd(program, args_list(args), stderr_to_stdout: true) do
+    result = System.cmd(program, args_list(args), stderr_to_stdout: true)
+    case result do
       {_, 0} ->
-        {:ok, %Waffle.File{file | path: new_path}}
+        {:ok, %Waffle.File{file | path: new_path, tempfile?: true}}
       {error_message, _exit_code} ->
         {:error, error_message}
     end

--- a/lib/waffle/transformations/convert.ex
+++ b/lib/waffle/transformations/convert.ex
@@ -9,7 +9,7 @@ defmodule Waffle.Transformations.Convert do
     result = System.cmd(program, args_list(args), stderr_to_stdout: true)
     case result do
       {_, 0} ->
-        {:ok, %Waffle.File{file | path: new_path, tempfile?: true}}
+        {:ok, %Waffle.File{file | path: new_path, is_tempfile?: true}}
       {error_message, _exit_code} ->
         {:error, error_message}
     end


### PR DESCRIPTION
https://github.com/stavro/arc/pull/285

from @dmarkow 
> Fixes #256
> 
> Arc creates temp files in the directory that `System.tmp_dir` returns, but never cleans up after itself. Running unchecked on a production server could result in running out of disk space. These temp files are created in three scenarios:
> 
> 1. The input is binary data
> 2. The input is a remote URL
> 3. During transformations for each version
> 
> Scenarios 1 and 2 seem very similar (converting something that isn't a local file path into a local file path), however scenario 1 was happening once per transformation (where 10 versions/transformations meant the binary data would be written to disk 10 separate times), whereas scenario 2 was happening once right at the beginning (the URL is retrieved and saved to disk immediately during `Arc.File.new/1`).
> 
> Scenario 3 creates a temp file for each transformation.
> 
> Changes:
> 
> * Write binary input to a tempfile one time during `Arc.File.new/1` rather than once per transformation (the tradeoff is that even with no transformations, it'll still write once, but this matches how remote URLs are handled)
> * Got rid of `Arc.File.ensure_path` as it was only there to convert binary data to a path which now happens automatically
> * Add a `tempfile?` attribute to `%Arc.File{}` that can be used later for cleanup (I preferred this over just testing the path to see if it's in the temp dir, otherwise there's a chance of deleting the input file itself if it was also in the temp dir)
> * After storing each version, the version's temp file is deleted (scenario 3)
> * After storing all of the versions, the input temp file is deleted if it exists (scenarios 1 and 2)
> * Added tests for checking temp files (had to change some of the setup/teardown logic in the tests, but they all pass including the S3 tests)




