### PR TITLE
URL decode remote filenames

### DIFF
--- a/lib/waffle/file.ex
+++ b/lib/waffle/file.ex
@@ -21,7 +21,8 @@ defmodule Waffle.File do
   # Given a remote file
   def new(remote_path = "http" <> _) do
     uri = URI.parse(remote_path)
-    filename = Path.basename(uri.path)
+    filename = uri.path |> Path.basename() |> URI.decode()
+
 
     case save_file(uri, filename) do
       {:ok, local_path} -> %Waffle.File{path: local_path, file_name: filename, is_tempfile?: true}

--- a/test/actions/store_test.exs
+++ b/test/actions/store_test.exs
@@ -95,6 +95,15 @@ defmodule WaffleTest.Actions.Store do
     end
   end
 
+  test "accepts remote files with spaces" do
+    with_mock Waffle.Storage.S3,
+      put: fn DummyDefinition, _, {%{file_name: "image two.png", path: _}, nil} ->
+        {:ok, "image two.png"}
+      end do
+      assert DummyDefinition.store("https://github.com/elixir-waffle/waffle/blob/master/test/support/image%20two.png") == {:ok, "image two.png"}
+    end
+  end
+
   test "accepts remote files with filenames" do
     with_mock Waffle.Storage.S3,
       put: fn DummyDefinition, _, {%{file_name: "newfavicon.ico", path: _}, nil} ->


### PR DESCRIPTION
When storing remote files using their URL, their filenames are URL encoded. This means that we need to URL-decode them if we want to keep the original ones.

Before this change, storing [the support file in this same repository][1]  would generate a file named `image%20two.png`. After this change, the file will be generated using the proper name: `image two.png`.

[1]: https://github.com/elixir-waffle/waffle/blob/master/test/support/image%20two.png