### PR TITLE
Adding support to definition bucket/1 that use `{file, scope}` as arg

### DIFF
--- a/lib/mix/tasks/g.ex
+++ b/lib/mix/tasks/g.ex
@@ -80,6 +80,10 @@ defmodule Mix.Tasks.Waffle do
       #   :custom_bucket_name
       # end
 
+      # def bucket({_file, scope}) do
+      #   scope.bucket || bucket()
+      # end
+
       # Whitelist file extensions:
       # def validate({file, _}) do
       #   file_extension = file.file_name |> Path.extname() |> String.downcase()

--- a/lib/waffle/definition/storage.ex
+++ b/lib/waffle/definition/storage.ex
@@ -114,6 +114,7 @@ defmodule Waffle.Definition.Storage do
       @async true
 
       def bucket, do: Application.fetch_env!(:waffle, :bucket)
+      def bucket({_file, _scope}), do: bucket()
       def asset_host, do: Application.get_env(:waffle, :asset_host)
       def filename(_, {file, _}), do: Path.basename(file.file_name, Path.extname(file.file_name))
       def storage_dir_prefix, do: Application.get_env(:waffle, :storage_dir_prefix, "")
@@ -131,6 +132,7 @@ defmodule Waffle.Definition.Storage do
                      default_url: 2,
                      __storage: 0,
                      bucket: 0,
+                     bucket: 1,
                      asset_host: 0
 
       @before_compile Waffle.Definition.Storage

--- a/lib/waffle/storage/s3.ex
+++ b/lib/waffle/storage/s3.ex
@@ -47,7 +47,7 @@ defmodule Waffle.Storage.S3 do
 
       def bucket, do: :some_custom_bucket_name
 
-  You also can get bucket information from file or scope when to already storaded files (url and delete)
+  You can also use the current scope to define a target bucket
 
       def bucket({_file, scope}), do: scope.bucket || bucket()
 

--- a/lib/waffle/storage/s3.ex
+++ b/lib/waffle/storage/s3.ex
@@ -47,6 +47,10 @@ defmodule Waffle.Storage.S3 do
 
       def bucket, do: :some_custom_bucket_name
 
+  You also can get bucket information from file or scope when to already storaded files (url and delete)
+
+      def bucket({_file, scope}), do: scope.bucket || bucket()
+
   ## Access Control Permissions
 
   Waffle defaults all uploads to `private`.  In cases where it is
@@ -136,7 +140,7 @@ defmodule Waffle.Storage.S3 do
 
   def put(definition, version, {file, scope}) do
     destination_dir = definition.storage_dir(version, {file, scope})
-    s3_bucket = s3_bucket(definition)
+    s3_bucket = s3_bucket(definition, {file, scope})
     s3_key = Path.join(destination_dir, file.file_name)
     acl = definition.acl(version, {file, scope})
 
@@ -156,7 +160,7 @@ defmodule Waffle.Storage.S3 do
   end
 
   def delete(definition, version, {file, scope}) do
-    s3_bucket(definition)
+    s3_bucket(definition, {file, scope})
     |> S3.delete_object(s3_key(definition, version, {file, scope}))
     |> ExAws.request()
 
@@ -215,7 +219,7 @@ defmodule Waffle.Storage.S3 do
     options = put_in options[:virtual_host], virtual_host()
     config = Config.new(:s3, Application.get_all_env(:ex_aws))
     s3_key = s3_key(definition, version, file_and_scope)
-    s3_bucket = s3_bucket(definition)
+    s3_bucket = s3_bucket(definition, file_and_scope)
     {:ok, url} = S3.presigned_url(config, :get, s3_bucket, s3_key, options)
     url
   end
@@ -253,10 +257,12 @@ defmodule Waffle.Storage.S3 do
     Application.get_env(:waffle, :virtual_host) || false
   end
 
-  defp s3_bucket(definition) do
-    case definition.bucket() do
-      {:system, env_var} when is_binary(env_var) -> System.get_env(env_var)
-      name -> name
-    end
+  defp s3_bucket(definition), do: definition.bucket() |> parse_bucket()
+
+  defp s3_bucket(definition, file_and_scope) do
+    definition.bucket(file_and_scope) |> parse_bucket()
   end
+
+  defp parse_bucket({:system, env_var}) when is_binary(env_var), do: System.get_env(env_var)
+  defp parse_bucket(name), do: name
 end


### PR DESCRIPTION
This PR add support o `bucket/1`.

ex:

```elixir
      def bucket({_file, scope}) do
        scope.bucket || bucket()
      end
```

this new option don't change the current behavior, but add more flexibility to get the bucket from the scope.

This can be useful for applications with storage files from multiple environments, or that divide storage by context, such as applications with multi-tenant