### PR TITLE
If a `content-disposition` header is set, use that rather than the URI to set the filename.

### DIFF
--- a/lib/waffle/file.ex
+++ b/lib/waffle/file.ex
@@ -24,7 +24,7 @@ defmodule Waffle.File do
     filename = uri.path |> Path.basename() |> URI.decode()
 
     case save_file(uri, filename) do
-      {:ok, filename, local_path} -> %Waffle.File{path: local_path, file_name: filename, is_tempfile?: true}
+      {:ok, local_path, filename} -> %Waffle.File{path: local_path, file_name: filename, is_tempfile?: true}
       {:ok, local_path} -> %Waffle.File{path: local_path, file_name: filename, is_tempfile?: true}
       :error -> {:error, :invalid_file_path}
     end
@@ -94,7 +94,7 @@ defmodule Waffle.File do
       |> Kernel.<>(Path.extname(filename))
 
     case save_temp_file(local_path, uri) do
-      {:ok, filename} -> {:ok, filename, local_path}
+      {:ok, filename} -> {:ok, local_path, filename}
       :ok -> {:ok, local_path}
       _ -> :error
     end

--- a/lib/waffle/file.ex
+++ b/lib/waffle/file.ex
@@ -136,20 +136,7 @@ defmodule Waffle.File do
       {:ok, 200, headers, client_ref} -> 
         {:ok, body} = :hackney.body(client_ref)
         headers = :hackney_headers.new(headers)
-        filename = case :hackney_headers.get_value("content-disposition", headers) do
-          :undefined ->
-            nil
-
-          value ->
-            case :hackney_headers.content_disposition(value) do
-              {_, [{"filename", filename} | _]} ->
-                filename
-
-              _ ->
-                nil
-            end
-        end
-
+        filename = content_disposition(headers)
         if is_nil(filename) do
           {:ok, body}
         else
@@ -162,6 +149,22 @@ defmodule Waffle.File do
         end
 
       _ -> {:error, :waffle_hackney_error}
+    end
+  end
+
+  defp content_disposition(headers) do
+    case :hackney_headers.get_value("content-disposition", headers) do
+      :undefined ->
+        nil
+
+      value ->
+        case :hackney_headers.content_disposition(value) do
+          {_, [{"filename", filename} | _]} ->
+            filename
+
+          _ ->
+            nil
+        end
     end
   end
 

--- a/lib/waffle/file.ex
+++ b/lib/waffle/file.ex
@@ -104,7 +104,7 @@ defmodule Waffle.File do
     remote_file = get_remote_path(remote_path)
 
     case remote_file do
-      {:ok, filename, body} -> 
+      {:ok, body, filename} ->
         case File.write(local_path, body) do
           :ok -> {:ok, filename}
           _ -> :error
@@ -133,14 +133,14 @@ defmodule Waffle.File do
 
   defp request(remote_path, options, tries \\ 0) do
     case :hackney.get(URI.to_string(remote_path), [], "", options) do
-      {:ok, 200, headers, client_ref} -> 
+      {:ok, 200, headers, client_ref} ->
         {:ok, body} = :hackney.body(client_ref)
         headers = :hackney_headers.new(headers)
         filename = content_disposition(headers)
         if is_nil(filename) do
           {:ok, body}
         else
-          {:ok, filename, body}
+          {:ok, body, filename}
         end
       {:error, %{reason: :timeout}} ->
         case retry(tries, options) do

--- a/test/actions/store_test.exs
+++ b/test/actions/store_test.exs
@@ -98,6 +98,25 @@ defmodule WaffleTest.Actions.Store do
     end
   end
 
+  test "sets remote filename from content-disposition header when available" do
+    with_mocks ([
+      {Waffle.Storage.S3,
+        [],
+        [put: fn DummyDefinition, _, {%{file_name: "favicon.ico", path: _}, nil} ->
+          {:ok, "favicon.ico"}
+        end]
+      },
+      {Waffle.File,
+        [],
+        [content_disposition: fn _ ->
+          "favicon.ico"
+        end]
+      },
+      ]) do
+      assert DummyDefinition.store("https://www.google.com/favicon2.ico") == {:ok, "favicon.ico"}
+    end
+  end
+
   test "accepts remote files with spaces" do
     with_mock Waffle.Storage.S3,
       put: fn DummyDefinition, _, {%{file_name: "image two.png", path: _}, nil} ->


### PR DESCRIPTION
references #37 