### PR TITLE
ex_aws needs to be at least 2.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ defp deps do
     {:waffle, "~> 1.0.1"},
 
     # If using S3:
-    {:ex_aws, "~> 2.1"},
+    {:ex_aws, "~> 2.1.2"},
     {:ex_aws_s3, "~> 2.0"},
     {:hackney, "~> 1.9"},
     {:sweet_xml, "~> 0.6"}


### PR DESCRIPTION
Otherwise, you're trying to access an undefined sanatise/2 method:

[see](https://github.com/ex-aws/ex_aws/commit/ecd51b1965909119ee597d6c0783334e30e59e58)