### PR TITLE
add Aliyun OSS storage provider link

### DIFF
--- a/lib/waffle.ex
+++ b/lib/waffle.ex
@@ -52,6 +52,8 @@ defmodule Waffle do
 
     * **Microsoft Azure Storage** - [arc_azure](https://github.com/phil-a/arc_azure])
 
+    * **Aliyun OSS Storage** - [waffle_aliyun_oss](https://github.com/ug0/waffle_aliyun_oss)
+
   ## Usage with Ecto
 
   Waffle comes with a companion package for use with Ecto.  If you


### PR DESCRIPTION
I've just published v0.1.0 of [waffle_aliyun_oss](https://github.com/ug0/waffle_aliyun_oss), a hex package to support
Aliyun OSS([Alibaba Cloud Object Storage Service](https://www.alibabacloud.com/product/oss)) storage for waffle.
