### PR TITLE
Update path in getting started guide to the correct generated path

### DIFF
--- a/lib/waffle.ex
+++ b/lib/waffle.ex
@@ -83,7 +83,7 @@ defmodule Waffle do
 
   This should give you a basic file in:
 
-      web/uploaders/avatar.ex
+      lib/[APP_NAME]_web/uploaders/avatar.ex
 
   Check this file for descriptions of configurable options.
 


### PR DESCRIPTION
When reading the getting started guide, I noticed that the path the file would be generated in was not fully specified. I was unsure if the library had not been updated since the change in directory structure in Phoenix, but a quick browse through the code confirms that this was fixed before Waffle forked from Arc. In that case, I thought it best to update the docs so nobody else has the same thought process I had. Let me know your thoughts!