### PR TITLE
fix | use correct extension when converting files

### DIFF
--- a/lib/waffle/file.ex
+++ b/lib/waffle/file.ex
@@ -3,6 +3,19 @@ defmodule Waffle.File do
 
   defstruct [:path, :file_name, :binary, :is_tempfile?]
 
+  #
+  # Temp file with exact extension. Used for converting formats
+  # Used when passing extension in transformations
+  #
+  def generate_temporary_path(extension) when is_atom(extension) do
+    file_name =
+      :crypto.strong_rand_bytes(20)
+      |> Base.encode32()
+      |> Kernel.<>("." <> to_string(extension))
+
+    Path.join(System.tmp_dir(), file_name)
+  end
+
   def generate_temporary_path(file \\ nil) do
     extension = Path.extname((file && file.path) || "")
 

--- a/lib/waffle/file.ex
+++ b/lib/waffle/file.ex
@@ -3,28 +3,8 @@ defmodule Waffle.File do
 
   defstruct [:path, :file_name, :binary, :is_tempfile?]
 
-  #
-  # Temp file with exact extension. Used for converting formats
-  # Used when passing extension in transformations
-  #
-  def generate_temporary_path(extension) when is_atom(extension) do
-    file_name =
-      :crypto.strong_rand_bytes(20)
-      |> Base.encode32()
-      |> Kernel.<>("." <> to_string(extension))
-
-    Path.join(System.tmp_dir(), file_name)
-  end
-
-  def generate_temporary_path(file \\ nil) do
-    extension = Path.extname((file && file.path) || "")
-
-    file_name =
-      :crypto.strong_rand_bytes(20)
-      |> Base.encode32()
-      |> Kernel.<>(extension)
-
-    Path.join(System.tmp_dir(), file_name)
+  def generate_temporary_path(item \\ nil) do
+    do_generate_temporary_path(item)
   end
 
   #
@@ -102,6 +82,31 @@ defmodule Waffle.File do
   #
   # Support functions
   #
+
+  #
+  #
+  # Temp file with exact extension.
+  # Used for converting formats when passing extension in transformations
+  #
+
+  defp do_generate_temporary_path(%Waffle.File{path: path}) do
+    Path.extname(path || "")
+    |> do_generate_temporary_path()
+  end
+
+  defp do_generate_temporary_path(extension) do
+    string_extension =
+      extension
+      |> to_string()
+      |> (fn ext -> if !String.starts_with?(ext, ["", "."]), do: ".#{ext}", else: ext end).()
+
+    file_name =
+      :crypto.strong_rand_bytes(20)
+      |> Base.encode32()
+      |> Kernel.<>("." <> string_extension)
+
+    Path.join(System.tmp_dir(), file_name)
+  end
 
   defp write_binary(file) do
     path = generate_temporary_path(file)

--- a/lib/waffle/processor.ex
+++ b/lib/waffle/processor.ex
@@ -147,12 +147,14 @@ defmodule Waffle.Processor do
 
   defp apply_transformation(_, :skip), do: {:ok, nil}
   defp apply_transformation(file, :noaction), do: {:ok, file}
-  defp apply_transformation(file, {:noaction}), do: {:ok, file} # Deprecated
-  defp apply_transformation(file, {cmd, conversion, _}) do
-    apply_transformation(file, {cmd, conversion})
-  end
+  # Deprecated
+  defp apply_transformation(file, {:noaction}), do: {:ok, file}
 
   defp apply_transformation(file, {cmd, conversion}) do
     Convert.apply(cmd, file, conversion)
+  end
+
+  defp apply_transformation(file, {cmd, conversion, extension}) do
+    Convert.apply(cmd, file, conversion, extension)
   end
 end

--- a/lib/waffle/transformations/convert.ex
+++ b/lib/waffle/transformations/convert.ex
@@ -1,17 +1,27 @@
 defmodule Waffle.Transformations.Convert do
   @moduledoc false
 
-  def apply(cmd, file, args) do
-    new_path = Waffle.File.generate_temporary_path(file)
-    args     = if is_function(args), do: args.(file.path, new_path), else: [file.path | (String.split(args, " ") ++ [new_path])]
-    program  = to_string(cmd)
+  def apply(cmd, file, args, extension \\ nil) do
+    new_path =
+      if extension,
+        do: Waffle.File.generate_temporary_path(extension),
+        else: Waffle.File.generate_temporary_path(file)
+
+    args =
+      if is_function(args),
+        do: args.(file.path, new_path),
+        else: [file.path | String.split(args, " ") ++ [new_path]]
+
+    program = to_string(cmd)
 
     ensure_executable_exists!(program)
 
     result = System.cmd(program, args_list(args), stderr_to_stdout: true)
+
     case result do
       {_, 0} ->
         {:ok, %Waffle.File{file | path: new_path, is_tempfile?: true}}
+
       {error_message, _exit_code} ->
         {:error, error_message}
     end

--- a/test/processor_test.exs
+++ b/test/processor_test.exs
@@ -10,9 +10,18 @@ defmodule WaffleTest.Processor do
     def validate({file, _}), do: String.ends_with?(file.file_name, ".png")
     def transform(:original, _), do: :noaction
     def transform(:thumb, _), do: {:convert, "-strip -thumbnail 10x10"}
-    def transform(:med, _), do: {:convert, fn(input, output) -> " #{input} -strip -thumbnail 10x10 #{output}" end, :jpg}
-    def transform(:small, _), do: {:convert, fn(input, output) -> [input, "-strip", "-thumbnail", "10x10", output] end, :jpg}
+
+    def transform(:med, _),
+      do: {:convert, fn input, output -> " #{input} -strip -thumbnail 10x10 #{output}" end, :jpg}
+
+    def transform(:small, _),
+      do:
+        {:convert, fn input, output -> [input, "-strip", "-thumbnail", "10x10", output] end, :jpg}
+
+    def transform(:new_format, _), do: {:convert, "-quality 40", :webp}
+
     def transform(:skipped, _), do: :skip
+
     def __versions, do: [:original, :thumb]
   end
 
@@ -33,62 +42,110 @@ defmodule WaffleTest.Processor do
   end
 
   test "returns the original path for :noaction transformations" do
-    {:ok, file} = Waffle.Processor.process(DummyDefinition, :original, {Waffle.File.new(@img), nil})
+    {:ok, file} =
+      Waffle.Processor.process(DummyDefinition, :original, {Waffle.File.new(@img), nil})
+
     assert file.path == @img
   end
 
   test "returns nil for :skip transformations" do
-    assert {:ok, nil} = Waffle.Processor.process(DummyDefinition, :skipped, {Waffle.File.new(@img), nil})
+    assert {:ok, nil} =
+             Waffle.Processor.process(DummyDefinition, :skipped, {Waffle.File.new(@img), nil})
   end
 
   test "transforms a copied version of file according to the specified transformation" do
-    {:ok, new_file} = Waffle.Processor.process(DummyDefinition, :thumb, {Waffle.File.new(@img), nil})
+    {:ok, new_file} =
+      Waffle.Processor.process(DummyDefinition, :thumb, {Waffle.File.new(@img), nil})
+
     assert new_file.path != @img
-    assert "128x128" == geometry(@img) #original file untouched
+    # original file untouched
+    assert "128x128" == geometry(@img)
     assert "10x10" == geometry(new_file.path)
     cleanup(new_file.path)
   end
 
   test "transforms a copied version of file according to a function transformation that returns a string" do
-    {:ok, new_file} = Waffle.Processor.process(DummyDefinition, :med, {Waffle.File.new(@img), nil})
+    {:ok, new_file} =
+      Waffle.Processor.process(DummyDefinition, :med, {Waffle.File.new(@img), nil})
+
     assert new_file.path != @img
-    assert "128x128" == geometry(@img) #original file untouched
+    # original file untouched
+    assert "128x128" == geometry(@img)
     assert "10x10" == geometry(new_file.path)
     cleanup(new_file.path)
   end
 
   test "transforms a copied version of file according to a function transformation that returns a list" do
-    {:ok, new_file} = Waffle.Processor.process(DummyDefinition, :small, {Waffle.File.new(@img), nil})
+    {:ok, new_file} =
+      Waffle.Processor.process(DummyDefinition, :small, {Waffle.File.new(@img), nil})
+
     assert new_file.path != @img
-    assert "128x128" == geometry(@img) #original file untouched
+    # original file untouched
+    assert "128x128" == geometry(@img)
     assert "10x10" == geometry(new_file.path)
     cleanup(new_file.path)
   end
 
   test "transforms a file given as a binary" do
     img_binary = File.read!(@img)
-    {:ok, new_file} = Waffle.Processor.process(DummyDefinition, :small, {Waffle.File.new(%{binary: img_binary, filename: "image.png"}), nil})
+
+    {:ok, new_file} =
+      Waffle.Processor.process(
+        DummyDefinition,
+        :small,
+        {Waffle.File.new(%{binary: img_binary, filename: "image.png"}), nil}
+      )
+
     assert new_file.path != @img
-    assert "128x128" == geometry(@img) #original file untouched
+    # original file untouched
+    assert "128x128" == geometry(@img)
     assert "10x10" == geometry(new_file.path)
     cleanup(new_file.path)
   end
 
   test "file names with spaces" do
-    {:ok, new_file} = Waffle.Processor.process(DummyDefinition, :thumb, {Waffle.File.new(@img2), nil})
+    {:ok, new_file} =
+      Waffle.Processor.process(DummyDefinition, :thumb, {Waffle.File.new(@img2), nil})
+
     assert new_file.path != @img2
-    assert "128x128" == geometry(@img2) #original file untouched
+    # original file untouched
+    assert "128x128" == geometry(@img2)
     assert "10x10" == geometry(new_file.path)
     cleanup(new_file.path)
   end
 
+  test "converts file to correct format" do
+    {:ok, new_file} =
+      Waffle.Processor.process(DummyDefinition, :new_format, {Waffle.File.new(@img), nil})
+
+    # new tmp file has correct extension
+    assert Path.extname(new_file.path) == ".webp"
+
+    cleanup(new_file.path)
+  end
+
+  test "converts file to correct format via function transfomations" do
+    {:ok, new_file} =
+      Waffle.Processor.process(DummyDefinition, :small, {Waffle.File.new(@img), nil})
+
+    # new tmp file has correct extension
+    assert Path.extname(new_file.path) == ".jpg"
+
+    cleanup(new_file.path)
+  end
+
   test "returns tuple in an invalid transformation" do
-    assert {:error, _} = Waffle.Processor.process(BrokenDefinition, :thumb, {Waffle.File.new(@img), nil})
+    assert {:error, _} =
+             Waffle.Processor.process(BrokenDefinition, :thumb, {Waffle.File.new(@img), nil})
   end
 
   test "raises an error if the given transformation executable cannot be found" do
     assert_raise Waffle.MissingExecutableError, ~r"blah", fn ->
-      Waffle.Processor.process(MissingExecutableDefinition, :original, {Waffle.File.new(@img), nil})
+      Waffle.Processor.process(
+        MissingExecutableDefinition,
+        :original,
+        {Waffle.File.new(@img), nil}
+      )
     end
   end
 


### PR DESCRIPTION
### The problem
` Waffle.File.generate_temporary_path/1` generates tmp file with wrong extension if it is specified in `{:convert, transformations, :png}`
Generated tmp file should have extension specified in transform func