### PR TITLE
Fix typo in comment

### DIFF
--- a/lib/waffle/actions/store.ex
+++ b/lib/waffle/actions/store.ex
@@ -132,8 +132,8 @@ defmodule Waffle.Actions.Store do
 
         case definition.transform(version, {file, scope}) do
           :noaction ->
-            # we don't have to cleanup after `:noaction` transofmations
-            # because final `cleanup!` will remove the original temporary file
+            # We don't have to cleanup after `:noaction` transformations
+            # because final `cleanup!` will remove the original temporary file.
             result
           _ ->
             cleanup!(result, file)


### PR DESCRIPTION
Hello!

Thank you for this lib! I was just digging through the code and spotted a minor typo in a comment.

This commit fixes a typo in the word "transformations" and also adjusts the format of the comment to match the other in-code comment in the module. It starts now with an uppercase letter and the sentence ends with a dot (like the comment in `cleanup!`).