### PR TITLE
Add support for custom validation error message

### DIFF
--- a/documentation/examples/local.md
+++ b/documentation/examples/local.md
@@ -17,7 +17,11 @@ defmodule Avatar do
 
   def validate({file, _}) do
     file_extension = file.file_name |> Path.extname |> String.downcase
-    Enum.member?(@extension_whitelist, file_extension)
+
+    case Enum.member?(@extension_whitelist, file_extension) do
+      true -> :ok
+      false -> {:error, "file type is invalid"}
+    end
   end
 
   def transform(:thumb, _) do

--- a/lib/waffle/actions/store.ex
+++ b/lib/waffle/actions/store.ex
@@ -63,12 +63,18 @@ defmodule Waffle.Actions.Store do
   #
 
   defp put(_definition, {error = {:error, _msg}, _scope}), do: error
+
   defp put(definition, {%Waffle.File{} = file, scope}) do
     case definition.validate({file, scope}) do
-      true ->
+      result when result == true or result == :ok ->
         put_versions(definition, {file, scope})
         |> cleanup!(file)
-      _    -> {:error, :invalid_file}
+
+      {:error, message} ->
+        {:error, message}
+
+      _ ->
+        {:error, :invalid_file}
     end
   end
 

--- a/lib/waffle/definition/storage.ex
+++ b/lib/waffle/definition/storage.ex
@@ -74,12 +74,18 @@ defmodule Waffle.Definition.Storage do
 
         def validate({file, _}) do
           file_extension = file.file_name |> Path.extname() |> String.downcase()
-          Enum.member?(@extension_whitelist, file_extension)
+
+          case Enum.member?(@extension_whitelist, file_extension) do
+            true -> :ok
+            false -> {:error, "invalid file type"}
+          end
         end
       end
 
-  Any uploaded file failing validation will return `{:error, :invalid_file}` when
-  passed through to `Avatar.store`.
+  Validation will be considered successful if the function returns `true` or `:ok`.
+  A customized error message can be returned in the form of `{:error, message}`.
+  Any other return value will return `{:error, :invalid_file}` when passed through
+  to `Avatar.store`.
 
   ## Passing custom headers when downloading from remote path
 

--- a/test/actions/store_test.exs
+++ b/test/actions/store_test.exs
@@ -27,12 +27,25 @@ defmodule WaffleTest.Actions.Store do
     def remote_file_headers(%URI{host: "www.google.com"}), do: [{"User-Agent", "MyApp"}]
   end
 
+  defmodule DummyDefinitionWithValidationError do
+    use Waffle.Actions.Store
+    use Waffle.Definition.Storage
+
+    def validate(_), do: {:error, "invalid file type"}
+    def transform(_, _), do: :noaction
+    def __versions, do: [:original, :thumb, :skipped]
+  end
+
   test "checks file existance" do
     assert DummyDefinition.store("non-existant-file.png") == {:error, :invalid_file_path}
   end
 
   test "delegates to definition validation" do
     assert DummyDefinition.store(__ENV__.file) == {:error, :invalid_file}
+  end
+
+  test "supports custom validation error message" do
+    assert DummyDefinitionWithValidationError.store(__ENV__.file) == {:error, "invalid file type"}
   end
 
   test "single binary argument is interpreted as file path" do


### PR DESCRIPTION
This PR addresses https://github.com/elixir-waffle/waffle/issues/49.

Currently whenever `validate/1` returns anything other than `true`, `store/2` will always return `{:error, :invalid_file}`. This PR allows this error message to be customizable so that we can for instance return `{:error, "invalid file type"}` or `{:error, "file is too large"}`.

We will then be able to propagate this message down to waffle_ecto so that ultimately we can set a custom error message on Ecto.Changeset instead of the default "is invalid".