### PR TITLE
Fix links to other storage providers

### DIFF
--- a/lib/waffle.ex
+++ b/lib/waffle.ex
@@ -35,7 +35,7 @@ defmodule Waffle do
   * `Waffle.Storage.Local`
   * `Waffle.Storage.S3`
 
-  [Other available storage providers](#other-available-storage-providers)
+  [Other available storage providers](#module-other-storage-providers)
   are supported by the community.
 
   An example for setting up `Waffle.Storage.Local`:
@@ -103,7 +103,7 @@ defmodule Waffle do
 
     * **Google Cloud Storage** - [waffle_gcs](https://github.com/kolorahl/waffle_gcs)
 
-    * **Microsoft Azure Storage** - [arc_azure](https://github.com/phil-a/arc_azure])
+    * **Microsoft Azure Storage** - [arc_azure](https://github.com/phil-a/arc_azure)
 
     * **Aliyun OSS Storage** - [waffle_aliyun_oss](https://github.com/ug0/waffle_aliyun_oss)
 


### PR DESCRIPTION
Hi, I'm new here and I'm interested in learning about this package. While reading, I noticed some links are broken in the [documentation](https://hexdocs.pm/waffle/Waffle.html) and want to fix them:
- link to "Other Storage Providers" section
- link to "arc_azure" github repo page