### PR TITLE
Add path/4 for storage backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,28 @@ dependency.  Benefits include:
   * **Microsoft Azure Storage** - [arc_azure](https://github.com/phil-a/arc_azure)
 
   * **Aliyun OSS Storage** - [waffle_aliyun_oss](https://github.com/ug0/waffle_aliyun_oss)
+  
+## Testing
+
+The basic test suite can be run with without supplying any S3 information:
+
+```
+mix test
+```
+
+In order to test S3 capability, you must have access to an S3/equivalent bucket. For
+S3 buckets, the bucket must be configured to allow ACLs and it must allow public
+access.
+
+The following environment variables will be used by the test suite:
+
+* WAFFLE_TEST_BUCKET
+* WAFFLE_TEST_BUCKET2
+* WAFFLE_TEST_S3_KEY
+* WAFFLE_TEST_S3_SECRET
+* WAFFLE_TEST_REGION
+
+After setting these variables, you can run the full test suite with `mix test --include s3:true`.
 
 ## Attribution
 

--- a/lib/waffle/storage/local.ex
+++ b/lib/waffle/storage/local.ex
@@ -42,22 +42,22 @@ defmodule Waffle.Storage.Local do
   end
 
   def url(definition, version, file_and_scope, _options \\ []) do
-    path = path(definition, version, file_and_scope)
+    local_path = Path.join(
+      definition.storage_dir(version, file_and_scope),
+      Versioning.resolve_file_name(definition, version, file_and_scope)
+    )
     host = host(definition)
 
     if host == nil do
-      Path.join("/", path)
+      Path.join("/", local_path)
     else
-      Path.join(host, path)
+      Path.join(host, local_path)
     end
     |> URI.encode()
   end
 
-  def path(definition, version, file_and_scope) do
-    Path.join(
-      definition.storage_dir(version, file_and_scope),
-      Versioning.resolve_file_name(definition, version, file_and_scope)
-    )
+  def path(definition, version, file_and_scope, _options \\ []) do
+    url(definition, version, file_and_scope)
   end
 
   def delete(definition, version, file_and_scope) do

--- a/lib/waffle/storage/local.ex
+++ b/lib/waffle/storage/local.ex
@@ -42,18 +42,22 @@ defmodule Waffle.Storage.Local do
   end
 
   def url(definition, version, file_and_scope, _options \\ []) do
-    local_path = Path.join([
-      definition.storage_dir(version, file_and_scope),
-      Versioning.resolve_file_name(definition, version, file_and_scope)
-    ])
+    path = path(definition, version, file_and_scope)
     host = host(definition)
 
     if host == nil do
-      Path.join("/", local_path)
+      Path.join("/", path)
     else
-      Path.join([host, local_path])
+      Path.join(host, path)
     end
     |> URI.encode()
+  end
+
+  def path(definition, version, file_and_scope) do
+    Path.join(
+      definition.storage_dir(version, file_and_scope),
+      Versioning.resolve_file_name(definition, version, file_and_scope)
+    )
   end
 
   def delete(definition, version, file_and_scope) do

--- a/lib/waffle/storage/s3.ex
+++ b/lib/waffle/storage/s3.ex
@@ -159,6 +159,11 @@ defmodule Waffle.Storage.S3 do
     end
   end
 
+  def path(definition, version, file_and_scope, _options \\ []) do
+    s3_key(definition, version, file_and_scope)
+    |> Url.sanitize(:s3)
+  end
+
   def delete(definition, version, {file, scope}) do
     s3_bucket(definition, {file, scope})
     |> S3.delete_object(s3_key(definition, version, {file, scope}))
@@ -204,11 +209,10 @@ defmodule Waffle.Storage.S3 do
   end
 
   defp build_url(definition, version, file_and_scope, _options) do
-    asset_path =
-      s3_key(definition, version, file_and_scope)
-      |> Url.sanitize(:s3)
-
-    Path.join(host(definition, file_and_scope), asset_path)
+    Path.join(
+      host(definition, file_and_scope),
+      path(definition, version, file_and_scope)
+    )
   end
 
   defp build_signed_url(definition, version, file_and_scope, options) do

--- a/test/storage/local_test.exs
+++ b/test/storage/local_test.exs
@@ -83,6 +83,8 @@ defmodule WaffleTest.Storage.Local do
     assert File.exists?("waffletest/uploads/1/thumb-image.png")
     assert "/waffletest/uploads/original-image.png" == DummyDefinition.url("image.png", :original)
     assert "/waffletest/uploads/1/thumb-image.png" == DummyDefinition.url("1/image.png", :thumb)
+    assert "/waffletest/uploads/original-image.png" == DummyDefinition.path("image.png", :original)
+    assert "/waffletest/uploads/1/thumb-image.png" == DummyDefinition.path("1/image.png", :thumb)
 
     :ok = Local.delete(DummyDefinition, :original, {%{file_name: "image.png"}, nil})
     :ok = Local.delete(DummyDefinition, :thumb, {%{file_name: "image.png"}, nil})

--- a/test/storage/s3_test.exs
+++ b/test/storage/s3_test.exs
@@ -138,7 +138,7 @@ defmodule WaffleTest.Storage.S3 do
     # Application.put_env :ex_aws, :s3, [scheme: "https://", host: "s3.amazonaws.com", region: "us-west-2"]
     Application.put_env(:ex_aws, :access_key_id, System.get_env("WAFFLE_TEST_S3_KEY"))
     Application.put_env(:ex_aws, :secret_access_key, System.get_env("WAFFLE_TEST_S3_SECRET"))
-    Application.put_env(:ex_aws, :region, "eu-north-1")
+    Application.put_env(:ex_aws, :region, System.get_env("WAFFLE_TEST_REGION", "eu-north-1"))
     # Application.put_env :ex_aws, :scheme, "https://"
   end
 
@@ -160,11 +160,13 @@ defmodule WaffleTest.Storage.S3 do
     with_env(:waffle, :virtual_host, true, fn ->
       assert "https://#{env_bucket()}.s3.amazonaws.com/waffletest/uploads/image.png" ==
                DummyDefinition.url(@img)
+      assert "/waffletest/uploads/image.png" == DummyDefinition.path(@img)
     end)
 
     with_env(:waffle, :virtual_host, false, fn ->
       assert "https://s3.amazonaws.com/#{env_bucket()}/waffletest/uploads/image.png" ==
                DummyDefinition.url(@img)
+      assert "/waffletest/uploads/image.png" == DummyDefinition.path(@img)
     end)
   end
 


### PR DESCRIPTION
In order to make the object path available from the S3 backend (e.g. for
direct access via ex-aws-s3), refactor path logic into a new public
function.