### PR TITLE
Expose s3 key

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,28 @@ dependency.  Benefits include:
   * **Microsoft Azure Storage** - [arc_azure](https://github.com/phil-a/arc_azure)
 
   * **Aliyun OSS Storage** - [waffle_aliyun_oss](https://github.com/ug0/waffle_aliyun_oss)
+  
+## Testing
+
+The basic test suite can be run with without supplying any S3 information:
+
+```
+mix test
+```
+
+In order to test S3 capability, you must have access to an S3/equivalent bucket. For
+S3 buckets, the bucket must be configured to allow ACLs and it must allow public
+access.
+
+The following environment variables will be used by the test suite:
+
+* WAFFLE_TEST_BUCKET
+* WAFFLE_TEST_BUCKET2
+* WAFFLE_TEST_S3_KEY
+* WAFFLE_TEST_S3_SECRET
+* WAFFLE_TEST_REGION
+
+After setting these variables, you can run the full test suite with `mix test --include s3:true`.
 
 ## Attribution
 

--- a/lib/waffle/storage/s3.ex
+++ b/lib/waffle/storage/s3.ex
@@ -167,6 +167,13 @@ defmodule Waffle.Storage.S3 do
     :ok
   end
 
+  def s3_key(definition, version, file_and_scope) do
+    Path.join([
+      definition.storage_dir(version, file_and_scope),
+      Versioning.resolve_file_name(definition, version, file_and_scope)
+    ])
+  end
+
   #
   # Private
   #
@@ -223,13 +230,6 @@ defmodule Waffle.Storage.S3 do
     s3_bucket = s3_bucket(definition, file_and_scope)
     {:ok, url} = S3.presigned_url(config, :get, s3_bucket, s3_key, options)
     url
-  end
-
-  defp s3_key(definition, version, file_and_scope) do
-    Path.join([
-      definition.storage_dir(version, file_and_scope),
-      Versioning.resolve_file_name(definition, version, file_and_scope)
-    ])
   end
 
   defp host(definition, file_and_scope) do

--- a/test/storage/s3_test.exs
+++ b/test/storage/s3_test.exs
@@ -138,7 +138,7 @@ defmodule WaffleTest.Storage.S3 do
     # Application.put_env :ex_aws, :s3, [scheme: "https://", host: "s3.amazonaws.com", region: "us-west-2"]
     Application.put_env(:ex_aws, :access_key_id, System.get_env("WAFFLE_TEST_S3_KEY"))
     Application.put_env(:ex_aws, :secret_access_key, System.get_env("WAFFLE_TEST_S3_SECRET"))
-    Application.put_env(:ex_aws, :region, "eu-north-1")
+    Application.put_env(:ex_aws, :region, System.get_env("WAFFLE_TEST_REGION", "eu-north-1"))
     # Application.put_env :ex_aws, :scheme, "https://"
   end
 


### PR DESCRIPTION
Make `Waffle.Storage.S3.s3_key/3` public, so that other modules can have access to the object path.

This PR supersedes https://github.com/elixir-waffle/waffle/pull/97 .