### PR TITLE
Add support for changing/adding file extension

### DIFF
--- a/lib/waffle/definition/versioning.ex
+++ b/lib/waffle/definition/versioning.ex
@@ -28,6 +28,9 @@ defmodule Waffle.Definition.Versioning do
     quote do
       @versions [:original]
       @before_compile Waffle.Definition.Versioning
+
+      def extension(_, {file, _}), do: Path.extname(file.file_name)
+      defoverridable extension: 2
     end
   end
 
@@ -38,7 +41,7 @@ defmodule Waffle.Definition.Versioning do
     case conversion do
       :skip       -> nil
       {_, _, ext} -> "#{name}.#{ext}"
-       _          -> "#{name}#{Path.extname(file.file_name)}"
+       _          -> "#{name}#{definition.extension(version, {file, scope})}"
     end
   end
 

--- a/test/actions/url_test.exs
+++ b/test/actions/url_test.exs
@@ -9,6 +9,7 @@ defmodule WaffleTest.Actions.Url do
     def __versions, do: [:original, :thumb, :skipped]
     def transform(:skipped, _), do: :skip
     def transform(_, _), do: :noaction
+    def extension(_, {file, _}), do: Path.extname(file.file_name)
     def default_url(version, scope) when is_nil(scope), do: "dummy-#{version}"
     def default_url(version, scope), do: "dummy-#{version}-#{scope}"
     def __storage, do: Waffle.Storage.S3


### PR DESCRIPTION
In some cases, like with LiveUpload, uploaded files get stored without extensions. This PR allows user to define transform/2 which returns the new extension.