### PR TITLE
Apply image transformation with provided function

### DIFF
--- a/lib/waffle/processor.ex
+++ b/lib/waffle/processor.ex
@@ -150,6 +150,9 @@ defmodule Waffle.Processor do
   # Deprecated
   defp apply_transformation(file, {:noaction}), do: {:ok, file}
 
+  defp apply_transformation(file, {:custom, {module, function, conversion}}),
+    do: apply(module, function, [file, conversion])
+
   defp apply_transformation(file, {cmd, conversion}) do
     Convert.apply(cmd, file, conversion)
   end


### PR DESCRIPTION
We encountered use case where using Lambda function for image processing proved to be more appropriate solution than using ImageMagick on the server.

PR would enable using custom defined functions as transformators and would therefore enable usage of Lambdas or other service for this purpose.