### PR TITLE
Refactor local storage example: `whitelist` » `acceptlist`

### DIFF
--- a/documentation/examples/local.md
+++ b/documentation/examples/local.md
@@ -13,12 +13,12 @@ defmodule Avatar do
   use Waffle.Definition
 
   @versions [:original, :thumb]
-  @extension_whitelist ~w(.jpg .jpeg .gif .png)
+  @extension_acceptlist ~w(.jpg .jpeg .gif .png)
 
   def validate({file, _}) do
     file_extension = file.file_name |> Path.extname |> String.downcase
 
-    case Enum.member?(@extension_whitelist, file_extension) do
+    case Enum.member?(@extension_acceptlist, file_extension) do
       true -> :ok
       false -> {:error, "file type is invalid"}
     end


### PR DESCRIPTION
Picked `acceptlist` as one of the [commonly used alternative terms for whitelist][1]

  [1]: https://abusix.com/resources/blocklists/why-changing-the-terms-blacklist-and-whitelist-isnt-as-easy-as-it-might-seem