### PR TITLE
Fix function call warning

### DIFF
--- a/lib/waffle/actions/url.ex
+++ b/lib/waffle/actions/url.ex
@@ -81,9 +81,9 @@ defmodule Waffle.Actions.Url do
   defmacro __using__(_) do
     quote do
       def urls(file, options \\ []) do
-        Enum.into __MODULE__.__versions, %{}, fn(r) ->
+        Enum.into(__MODULE__.__versions(), %{}, fn r ->
           {r, __MODULE__.url(file, r, options)}
-        end
+        end)
       end
 
       def url(file), do: url(file, nil)
@@ -100,8 +100,9 @@ defmodule Waffle.Actions.Url do
     do: url(definition, file, Enum.at(definition.__versions, 0), options)
 
   # Transform standalone file into a tuple of {file, scope}
-  def url(definition, file, version, options) when is_binary(file) or is_map(file) or is_nil(file),
-    do: url(definition, {file, nil}, version, options)
+  def url(definition, file, version, options)
+      when is_binary(file) or is_map(file) or is_nil(file),
+      do: url(definition, {file, nil}, version, options)
 
   # Transform file-path into a map with a file_name key
   def url(definition, {file, scope}, version, options) when is_binary(file) do
@@ -122,7 +123,9 @@ defmodule Waffle.Actions.Url do
 
   defp build(definition, version, file_and_scope, options) do
     case Versioning.resolve_file_name(definition, version, file_and_scope) do
-      nil -> nil
+      nil ->
+        nil
+
       _ ->
         definition.__storage.url(definition, version, file_and_scope, options)
     end


### PR DESCRIPTION
Elixir 1.16 throws warning when Waffle is `use`ed from a module due to missing parens around `__MODULE__.versions`.