### PR TITLE
Add support for extensions to custom transformations

### DIFF
--- a/lib/waffle/definition/versioning.ex
+++ b/lib/waffle/definition/versioning.ex
@@ -36,9 +36,18 @@ defmodule Waffle.Definition.Versioning do
     conversion = definition.transform(version, {file, scope})
 
     case conversion do
-      :skip       -> nil
-      {_, _, ext} -> "#{name}.#{ext}"
-       _          -> "#{name}#{Path.extname(file.file_name)}"
+      :skip ->
+        nil
+
+      {_, _, ext} ->
+        [name, ext] |> Enum.join(".")
+
+      {fn_transform, fn_extension}
+      when is_function(fn_transform) and is_function(fn_extension) ->
+        [name, fn_extension.(version, file)] |> Enum.join(".")
+
+      _ ->
+        [name, Path.extname(file.file_name)] |> Enum.join()
     end
   end
 

--- a/test/actions/store_test.exs
+++ b/test/actions/store_test.exs
@@ -18,6 +18,25 @@ defmodule WaffleTest.Actions.Store do
     def __versions, do: [:original, :thumb, :skipped]
   end
 
+  defmodule DummyDefinitionWithExtension do
+    use Waffle.Actions.Store
+    use Waffle.Definition.Storage
+
+    def validate({file, _}), do: String.ends_with?(file.file_name, ".png")
+
+    def transform(:convert_to_jpg, _),
+      do: {:convert, "-format jpg", :jpg}
+
+    def transform(:custom_to_jpg, {file, _}) do
+      {
+        fn _, _ -> {:ok, file} end,
+        fn _, _ -> :jpg end
+      }
+    end
+
+    def __versions, do: [:convert_to_jpg, :custom_to_jpg]
+  end
+
   defmodule DummyDefinitionWithHeaders do
     use Waffle.Actions.Store
     use Waffle.Definition.Storage
@@ -34,6 +53,15 @@ defmodule WaffleTest.Actions.Store do
     def validate(_), do: {:error, "invalid file type"}
     def transform(_, _), do: :noaction
     def __versions, do: [:original, :thumb, :skipped]
+  end
+
+  test "custom transformations change a file extension" do
+    with_mock Waffle.Storage.S3,
+      put: fn DummyDefinitionWithExtension, _, {%{file_name: "image.jpg", path: _}, nil} ->
+        {:ok, "resp"}
+      end do
+      assert DummyDefinitionWithExtension.store(@img) == {:ok, "image.png"}
+    end
   end
 
   test "checks file existence" do


### PR DESCRIPTION
Adds support for defining transformations with custom extensions

```elixir
 def transform(:custom_to_jpg, {file, _}) do
    {
      fn _, _ -> {:ok, file} end,
      fn _, _ -> :jpg end
    }
end
```