### PR TITLE
Add support for dynamic S3 configs per uploader

### DIFF
--- a/documentation/examples/s3.md
+++ b/documentation/examples/s3.md
@@ -42,6 +42,18 @@ defmodule Avatar do
   def default_url(:thumb) do
     "https://placehold.it/100x100"
   end
+
+  # if not defined it will use default S3 config which is obtained
+  # from config files
+  def s3_config({file, scope}) do
+    ExAws.Config.new(:s3,
+      access_key_id: "custom access key id",
+      secret_access_key: "custom secret access key",
+      host: "localhost",
+      scheme: "http://",
+      port: 9000
+    )
+  end
 end
 ```
 

--- a/lib/waffle/definition.ex
+++ b/lib/waffle/definition.ex
@@ -29,6 +29,15 @@ defmodule Waffle.Definition do
       use Waffle.Actions.Store
       use Waffle.Actions.Delete
       use Waffle.Actions.Url
+
+      @doc """
+      Define a custom configuration struct to connect to AWS S3
+      """
+      def s3_config({file, scope}) do
+        ExAws.Config.Defaults.defaults(:s3)
+      end
+
+      defoverridable [{:s3_config, 1}]
     end
   end
 end


### PR DESCRIPTION
In case definition.s3_config/0 is not defined it will use
ExAws.Config.Defaults.defaults(:s3) which was the default option
already