### PR TITLE
Fix module.function notation warnings in Elixir 1.17

### DIFF
--- a/lib/waffle/actions/delete.ex
+++ b/lib/waffle/actions/delete.ex
@@ -48,12 +48,12 @@ defmodule Waffle.Actions.Delete do
   end
 
   defp do_delete(definition, {file, scope}) do
-    if definition.async do
-      definition.__versions
+    if definition.async() do
+      definition.__versions()
       |> Enum.map(fn(r)     -> async_delete_version(definition, r, {file, scope}) end)
       |> Enum.each(fn(task) -> Task.await(task, version_timeout()) end)
     else
-      definition.__versions
+      definition.__versions()
       |> Enum.each(fn(version) -> delete_version(definition, version, {file, scope}) end)
     end
     :ok
@@ -68,7 +68,7 @@ defmodule Waffle.Actions.Delete do
     if conversion == :skip do
       :ok
     else
-      definition.__storage.delete(definition, version, {file, scope})
+      definition.__storage().delete(definition, version, {file, scope})
     end
   end
 end

--- a/lib/waffle/actions/store.ex
+++ b/lib/waffle/actions/store.ex
@@ -79,8 +79,8 @@ defmodule Waffle.Actions.Store do
   end
 
   defp put_versions(definition, {file, scope}) do
-    if definition.async do
-      definition.__versions
+    if definition.async() do
+      definition.__versions()
       |> Enum.map(fn(r)    -> async_process_version(definition, r, {file, scope}) end)
       |> Enum.map(fn(task) -> Task.await(task, version_timeout()) end)
       |> ensure_all_success
@@ -88,7 +88,7 @@ defmodule Waffle.Actions.Store do
       |> Enum.map(fn(task) -> Task.await(task, version_timeout()) end)
       |> handle_responses(file.file_name)
     else
-      definition.__versions
+      definition.__versions()
       |> Enum.map(fn(version) -> process_version(definition, version, {file, scope}) end)
       |> ensure_all_success
       |> Enum.map(fn({version, result}) -> put_version(definition, version, {result, scope}) end)
@@ -133,7 +133,7 @@ defmodule Waffle.Actions.Store do
       {:ok, file} ->
         file_name = Versioning.resolve_file_name(definition, version, {file, scope})
         file      = %Waffle.File{file | file_name: file_name}
-        result    = definition.__storage.put(definition, version, {file, scope})
+        result    = definition.__storage().put(definition, version, {file, scope})
 
         case definition.transform(version, {file, scope}) do
           :noaction ->

--- a/lib/waffle/actions/url.ex
+++ b/lib/waffle/actions/url.ex
@@ -81,7 +81,7 @@ defmodule Waffle.Actions.Url do
   defmacro __using__(_) do
     quote do
       def urls(file, options \\ []) do
-        Enum.into __MODULE__.__versions, %{}, fn(r) ->
+        Enum.into __MODULE__.__versions(), %{}, fn(r) ->
           {r, __MODULE__.url(file, r, options)}
         end
       end
@@ -97,7 +97,7 @@ defmodule Waffle.Actions.Url do
 
   # Apply default version if not specified
   def url(definition, file, nil, options),
-    do: url(definition, file, Enum.at(definition.__versions, 0), options)
+    do: url(definition, file, Enum.at(definition.__versions(), 0), options)
 
   # Transform standalone file into a tuple of {file, scope}
   def url(definition, file, version, options) when is_binary(file) or is_map(file) or is_nil(file),
@@ -124,7 +124,7 @@ defmodule Waffle.Actions.Url do
     case Versioning.resolve_file_name(definition, version, file_and_scope) do
       nil -> nil
       _ ->
-        definition.__storage.url(definition, version, file_and_scope, options)
+        definition.__storage().url(definition, version, file_and_scope, options)
     end
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -21,7 +21,7 @@
   "mock": {:hex, :mock, "0.3.7", "75b3bbf1466d7e486ea2052a73c6e062c6256fb429d6797999ab02fa32f29e03", [:mix], [{:meck, "~> 0.9.2", [hex: :meck, repo: "hexpm", optional: false]}], "hexpm", "4da49a4609e41fd99b7836945c26f373623ea968cfb6282742bcb94440cf7e5c"},
   "nimble_parsec": {:hex, :nimble_parsec, "1.2.3", "244836e6e3f1200c7f30cb56733fd808744eca61fd182f731eac4af635cc6d0b", [:mix], [], "hexpm", "c8d789e39b9131acf7b99291e93dae60ab48ef14a7ee9d58c6964f59efb570b0"},
   "parse_trans": {:hex, :parse_trans, "3.3.1", "16328ab840cc09919bd10dab29e431da3af9e9e7e7e6f0089dd5a2d2820011d8", [:rebar3], [], "hexpm", "07cd9577885f56362d414e8c4c4e6bdf10d43a8767abb92d24cbe8b24c54888b"},
-  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.6", "cf344f5692c82d2cd7554f5ec8fd961548d4fd09e7d22f5b62482e5aeaebd4b0", [:make, :mix, :rebar3], [], "hexpm", "bdb0d2471f453c88ff3908e7686f86f9be327d065cc1ec16fa4540197ea04680"},
+  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.7", "354c321cf377240c7b8716899e182ce4890c5938111a1296add3ec74cf1715df", [:make, :mix, :rebar3], [], "hexpm", "fe4c190e8f37401d30167c8c405eda19469f34577987c76dde613e838bbc67f8"},
   "sweet_xml": {:hex, :sweet_xml, "0.7.3", "debb256781c75ff6a8c5cbf7981146312b66f044a2898f453709a53e5031b45b", [:mix], [], "hexpm", "e110c867a1b3fe74bfc7dd9893aa851f0eed5518d0d7cad76d7baafd30e4f5ba"},
   "telemetry": {:hex, :telemetry, "1.2.1", "68fdfe8d8f05a8428483a97d7aab2f268aaff24b49e0f599faa091f1d4e7f61c", [:rebar3], [], "hexpm", "dad9ce9d8effc621708f99eac538ef1cbe05d6a874dd741de2e689c47feafed5"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.7.0", "bc84380c9ab48177092f43ac89e4dfa2c6d62b40b8bd132b1059ecc7232f9a78", [:rebar3], [], "hexpm", "25eee6d67df61960cf6a794239566599b09e17e668d3700247bc498638152521"},


### PR DESCRIPTION
Fixes the following warnings in Elixir 1.17:

```elixir
warning: using map.field notation (without parentheses) to invoke function WaffleTest.Actions.Store.DummyDefinition.async() is deprecated, you must add parentheses instead: remote.function()
  (waffle 1.1.8) lib/waffle/actions/store.ex:82: Waffle.Actions.Store.put_versions/2
  (waffle 1.1.8) lib/waffle/actions/store.ex:70: Waffle.Actions.Store.put/2
  test/actions/store_test.exs:232: WaffleTest.Actions.Store."test accepts remote files with spaces"/1
  (ex_unit 1.17.0-rc.0) lib/ex_unit/runner.ex:485: ExUnit.Runner.exec_test/2
  (stdlib 6.0) timer.erl:590: :timer.tc/2
  (ex_unit 1.17.0-rc.0) lib/ex_unit/runner.ex:407: anonymous fn/6 in ExUnit.Runner.spawn_test_monitor/4

warning: using map.field notation (without parentheses) to invoke function WaffleTest.Actions.Store.DummyDefinition.__storage() is deprecated, you must add parentheses instead: remote.function()
  (waffle 1.1.8) lib/waffle/actions/store.ex:136: Waffle.Actions.Store.put_version/3
  (elixir 1.17.0-rc.0) lib/task/supervised.ex:101: Task.Supervised.invoke_mfa/2
  (elixir 1.17.0-rc.0) lib/task/supervised.ex:36: Task.Supervised.reply/4

...
```

The first commit ships this fix https://github.com/deadtrickster/ssl_verify_fun.erl/pull/27 which is needed to run tests locally on Elixir 1.15+.