### PR TITLE
Add links to view source in docs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -35,6 +35,8 @@ defmodule Waffle.Mixfile do
   defp docs do
     [
       main: "Waffle",
+      source_ref: "v#{@version}",
+      source_url: "https://github.com/elixir-waffle/waffle",
       extras: [
         "documentation/examples/local.md",
         "documentation/examples/s3.md",


### PR DESCRIPTION
Hi!

This PR adds the ability to jump to the source from hex docs:

Clicking on:

<img width="991" alt="Screenshot 2024-06-06 at 8 02 26" src="https://github.com/elixir-waffle/waffle/assets/11598866/ae72bf2f-5451-4692-a4f3-f7f733514e8f">

takes you to: https://github.com/elixir-waffle/waffle/blob/v1.1.8/lib/waffle/actions/url.ex#L1