### PR TITLE
Override content disposition with provided filename

### DIFF
--- a/lib/waffle/file.ex
+++ b/lib/waffle/file.ex
@@ -44,6 +44,13 @@ defmodule Waffle.File do
     uri = URI.parse(remote_path)
 
     case save_file(uri, filename, definition) do
+      {:ok, local_path, _filename_from_content_disposition} ->
+        %Waffle.File{
+          path: local_path,
+          file_name: filename,
+          is_tempfile?: true
+        }
+
       {:ok, local_path} ->
         %Waffle.File{path: local_path, file_name: filename, is_tempfile?: true}
 


### PR DESCRIPTION
When provided to `store/1`
`%{filename: "some file.png", remote_path: "https://example.com/file"}` 
and the remote_path returns a content disposition header,
we get a unhandled CaseClause exception

example:

elixir
```
** (CaseClauseError) no case clause matching: {:ok, "/var/folders/mw/xdbkgz2n1fdgd75384n7mrr40000gn/T/WM2DEEDR55E4VNIPURIBLPMKV4DBLKFD.png", "image three.png"}
```

This PR fixes the above, by adding a case clause. It will use the provided `filename` rather than the filename
returned in the content disposition header.