### PR TITLE
fix: Return an error when a transform produces no output

### DIFF
--- a/lib/waffle/transformations/convert.ex
+++ b/lib/waffle/transformations/convert.ex
@@ -20,7 +20,11 @@ defmodule Waffle.Transformations.Convert do
 
     case result do
       {_, 0} ->
-        {:ok, %Waffle.File{file | path: new_path, is_tempfile?: true}}
+        if File.exists?(new_path) do
+          {:ok, %Waffle.File{file | path: new_path, is_tempfile?: true}}
+        else
+          {:error, "Transform output file does not exist: #{new_path}"}
+        end
 
       {error_message, _exit_code} ->
         {:error, error_message}

--- a/test/processor_test.exs
+++ b/test/processor_test.exs
@@ -67,6 +67,12 @@ defmodule WaffleTest.Processor do
     def transform(:original, _), do: {:blah, ""}
   end
 
+  defmodule MissingOutputDefinition do
+    use Waffle.Definition
+
+    def transform(:original, _), do: {"true", fn _input, _output -> [] end}
+  end
+
   test "returns the original path for :noaction transformations" do
     {:ok, file} =
       Waffle.Processor.process(
@@ -206,6 +212,17 @@ defmodule WaffleTest.Processor do
                :thumb,
                {Waffle.File.new(@img, BrokenDefinition), nil}
              )
+  end
+
+  test "returns an error when a successful transformation produces no output" do
+    assert {:error, message} =
+             Waffle.Processor.process(
+               MissingOutputDefinition,
+               :original,
+               {Waffle.File.new(@img, MissingOutputDefinition), nil}
+             )
+
+    assert message =~ "Transform output file does not exist:"
   end
 
   test "raises an error if the given transformation executable cannot be found" do


### PR DESCRIPTION
### Checklist

- [ ] I confirm that all text in the PR description, commit messages, code comments, and documentation is human-authored.

Fixes #87
